### PR TITLE
Implement account registration functionality with model, service, controller, and HTML form

### DIFF
--- a/src/main/java/com/page/dualnet/controller/RegistrationController.java
+++ b/src/main/java/com/page/dualnet/controller/RegistrationController.java
@@ -1,0 +1,47 @@
+package com.page.dualnet.controller;
+
+import com.page.dualnet.model.Account;
+import com.page.dualnet.service.AccountService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class RegistrationController {
+
+    private final AccountService accountService;
+
+    @Autowired
+    public RegistrationController(AccountService accountService) {
+        this.accountService = accountService;
+    }
+
+    @PostMapping("/register")
+    public String register(
+            @RequestParam String username,
+            @RequestParam String email,
+            @RequestParam(required = false) String password,
+            @RequestParam(required = false, name = "passwordConfirm") String passwordConfirm,
+            RedirectAttributes redirectAttributes
+    ) {
+        if (username == null || username.isBlank() || email == null || email.isBlank()) {
+            redirectAttributes.addAttribute("error", "missing");
+            return "redirect:/registration.html";
+        }
+
+        String p = password == null ? "" : password;
+        String pc = passwordConfirm == null ? "" : passwordConfirm;
+
+        if (!p.equals(pc)) {
+            redirectAttributes.addAttribute("error", "mismatch");
+            return "redirect:/register.html";
+        }
+
+        Account account = new Account(username.trim(), email.trim(), p);
+        accountService.save(account);
+        // on success, redirect to a welcome page
+        return "redirect:/Homepage.html";
+    }
+}

--- a/src/main/java/com/page/dualnet/model/Account.java
+++ b/src/main/java/com/page/dualnet/model/Account.java
@@ -1,0 +1,51 @@
+package com.page.dualnet.model;
+
+public class Account {
+    private String username;
+    private String email;
+    private String password;
+
+    public Account() {}
+
+    public Account(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        // CSV-escaped: username,email,password
+        return String.format("%s,%s,%s", escape(username), escape(email), escape(password));
+    }
+
+    private String escape(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\").replace(",", "\\,").replace("\n", "\\n");
+    }
+}
+

--- a/src/main/java/com/page/dualnet/service/AccountService.java
+++ b/src/main/java/com/page/dualnet/service/AccountService.java
@@ -1,0 +1,38 @@
+package com.page.dualnet.service;
+
+import com.page.dualnet.model.Account;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+@Service
+public class AccountService {
+    private final Path dataFile = Paths.get("data", "accounts.txt");
+
+    public AccountService() {
+        try {
+            Path dir = dataFile.getParent();
+            if (dir != null && !Files.exists(dir)) {
+                Files.createDirectories(dir);
+            }
+            if (!Files.exists(dataFile)) {
+                Files.createFile(dataFile);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to initialize accounts data file", e);
+        }
+    }
+
+    public synchronized void save(Account account) {
+        String line = account.toString() + System.lineSeparator();
+        try {
+            Files.write(dataFile, line.getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write account to file", e);
+        }
+    }
+}

--- a/src/main/resources/static/registration.html
+++ b/src/main/resources/static/registration.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/Icons/favicon.png" />
+  <link rel="apple-touch-icon" href="/Icons/favicon.png" />
+  <meta name="theme-color" content="#ffffff" />
+  <style>body{font-family:Arial,Helvetica,sans-serif;margin:40px}</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>DualNet - Registrierung</title>
+
+  <!-- Favicon: primary .ico at root, then png fallback, and Apple touch icon -->
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/Icons/favicon.png" />
+  <link rel="apple-touch-icon" href="/Icons/favicon.png" />
+  <meta name="theme-color" content="#ffffff" />
+
+  <style>
+    body{font-family:Arial,Helvetica,sans-serif;margin:40px}
+    form{max-width:400px}
+    label{display:block;margin-top:12px}
+    input{width:100%;padding:8px;margin-top:4px}
+    .msg{padding:10px;background:#e6ffe6;border:1px solid #b5ffb5;margin-bottom:12px}
+    .err{padding:10px;background:#ffe6e6;border:1px solid #ffb5b5;margin-bottom:12px}
+  </style>
+</head>
+<body>
+  <h1>Registrierung</h1>
+  <div id="message" style="display:none" class="msg">Registrierung erfolgreich!</div>
+  <div id="error" style="display:none" class="err"></div>
+
+  <form id="regForm" method="post" action="/register">
+    <label for="username">Benutzername</label>
+    <input id="username" name="username" required>
+
+    <label for="email">E-Mail</label>
+    <input id="email" name="email" type="email" required>
+
+    <label for="password">Passwort</label>
+    <input id="password" name="password" type="password">
+
+    <label for="passwordConfirm">Passwort wiederholen</label>
+    <input id="passwordConfirm" name="passwordConfirm" type="password">
+
+    <button style="margin-top:12px; padding:8px 12px" type="submit">Registrieren</button>
+  </form>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const errDiv = document.getElementById('error');
+    if (params.get('error') === 'missing') {
+      errDiv.textContent = 'Fehler: Bitte alle Pflichtfelder ausfüllen.';
+      errDiv.style.display = 'block';
+    } else if (params.get('error') === 'mismatch') {
+      errDiv.textContent = 'Fehler: Die Passwörter stimmen nicht überein.';
+      errDiv.style.display = 'block';
+    }
+
+    // optional client-side check to avoid a roundtrip when passwords don't match
+    document.getElementById('regForm').addEventListener('submit', function (e) {
+      const p = document.getElementById('password').value || '';
+      const pc = document.getElementById('passwordConfirm').value || '';
+      if (p !== pc) {
+        e.preventDefault();
+        errDiv.textContent = 'Fehler: Die Passwörter stimmen nicht überein.';
+        errDiv.style.display = 'block';
+        window.scrollTo(0,0);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pull request implements a user registration feature for the application. It introduces a registration form, a controller to handle registration requests, a model to represent user accounts, and a service to persist account data. The main changes are grouped into frontend and backend additions:

**Backend: Registration logic and persistence**

* Added `RegistrationController` to handle POST requests to `/register`, validate input, check password confirmation, and save new accounts using `AccountService`.
* Created `Account` model class to represent user accounts, including fields for username, email, and password, with CSV-style serialization and basic escaping.
* Implemented `AccountService` to persist account data in a file (`data/accounts.txt`), ensuring the data directory and file exist, and appending new accounts in a thread-safe way.

**Frontend: Registration form and validation**

* Added `registration.html` with a registration form for username, email, and password (with confirmation), styled error/success messages, and client-side validation to check for password mismatches before submitting.